### PR TITLE
[feat] 태그 목록 표시 및 태그 표출 로직 graphql로 수정

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -122,6 +122,10 @@ exports.createPages = async ({ graphql, actions }) => {
             }
           }
         }
+        tags: group(field: frontmatter___tags) {
+          tag: fieldValue
+          totalCount
+        }
       }
     }
   `);
@@ -142,23 +146,13 @@ exports.createPages = async ({ graphql, actions }) => {
     },
   });
 
-  const tags = [];
-  allMarkdown.data.allMarkdownRemark.edges.forEach(edge => {
-    if (edge.node.frontmatter.tags) {
-      tags.push(edge.node.frontmatter.tags.split(",").map(x => x.trim()));
-    }
-  });
-  const uniqueTags = tags.reduce(
-    (prev, tag) => (prev.find(x => x === tag) ? prev : prev.concat(tag)),
-    [],
-  );
-  uniqueTags.forEach(tag => {
+  const tags = allMarkdown.data.allMarkdownRemark.tags || [];
+  tags.forEach(({ tag, totalCount }) => {
     const tagPath = `tags/${tag}`;
     const matchedPosts = allMarkdown.data.allMarkdownRemark.edges.filter(
       edge =>
         edge.node.frontmatter.tags &&
         edge.node.frontmatter.tags
-          .split(",")
           .map(x => x.trim())
           .find(tagInPost => tagInPost === tag),
     );
@@ -170,7 +164,7 @@ exports.createPages = async ({ graphql, actions }) => {
         pathPrefix: tagPath,
         pageLength: 15,
         context: {
-          totalItems: matchedPosts.length,
+          totalItems: totalCount,
           tagName: tag,
         },
       });

--- a/src/components/Container.tsx
+++ b/src/components/Container.tsx
@@ -2,9 +2,10 @@ import * as React from "react";
 import styled from "@emotion/styled";
 
 import { breakpoints, widths } from "../styles/variables";
-import { getEmSize } from "../styles/mixins";
+import { clearfix, getEmSize } from "../styles/mixins";
 
 const StyledContainer = styled.div`
+  ${clearfix};
   margin-left: auto;
   margin-right: auto;
   width: auto;

--- a/src/components/Container.tsx
+++ b/src/components/Container.tsx
@@ -9,7 +9,7 @@ const StyledContainer = styled.div`
   margin-left: auto;
   margin-right: auto;
   width: auto;
-  max-width: ${getEmSize(widths.lg)}rem;
+  max-width: ${getEmSize(widths.xl)}rem;
   padding: 0 20px;
 
   @media (max-width: ${getEmSize(breakpoints.sm)}em) {

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -6,9 +6,11 @@ import { clearfix } from "../styles/mixins";
 import { colors } from "../styles/variables";
 
 export const NavigationWrapper = styled.nav`
-  ${clearfix} font-size: 0.875rem;
+  ${clearfix};
+  font-size: 0.875rem;
   font-weight: 600;
   color: ${colors.gray80};
+  margin: 0 10px;
   border-top: 1px solid ${colors.gray40};
 `;
 

--- a/src/components/PostList.tsx
+++ b/src/components/PostList.tsx
@@ -62,7 +62,7 @@ const ListItemImgWrapper = styled.figure`
 
   @media (max-width: ${getEmSize(
       breakpoints.md,
-    )}em) and (max-width: ${getEmSize(breakpoints.lg)}em) {
+    )}em) and (max-width: ${getEmSize(breakpoints.xl)}em) {
     margin-left: 40px;
   }
 

--- a/src/components/TOC.tsx
+++ b/src/components/TOC.tsx
@@ -108,7 +108,7 @@ const TOCList = styled.div`
       }
     }
 
-    &:not(:first-child) {
+    &:not(:first-of-type) {
       padding-left: 1rem;
     }
   }

--- a/src/content/javascript-in-2017/index.md
+++ b/src/content/javascript-in-2017/index.md
@@ -2,7 +2,7 @@
 layout: post
 title: "JavaScript in 2017: 옛날 사람 탈출하기"
 date: "2017-03-27"
-tags: "web"
+tags: ["web"]
 author: 최태건
 authorDesc: "플랫폼셀에서 웹 프론트엔드 개발을 담당하고 있습니다"
 titleImage: "./title.png"

--- a/src/content/react-hexagonal-binning/index.md
+++ b/src/content/react-hexagonal-binning/index.md
@@ -2,7 +2,7 @@
 layout: post
 title: "React, Google Maps, D3 를 이용한 Hexagonal Binning 기법"
 date: "2016-09-26"
-tags: "web"
+tags: ["web"]
 author: 윤현규
 authorDesc:
 titleImage: "./title.png"

--- a/src/content/react-ts-canvas-photo-upload/index.md
+++ b/src/content/react-ts-canvas-photo-upload/index.md
@@ -2,7 +2,7 @@
 layout: post
 title: "React-TypeScript 프로덕트에서 인물사진 유효성 검사하기"
 date: "2018-07-16"
-tags: react, typescript, google api, canvas
+tags: ["react", "typescript", "google api", "canvas"]
 author: 강민경
 titleImage: "./header.png"
 github: https://github.com/ClareKang/react-ts-canvas-photo-upload

--- a/src/content/vroong-tms-folder-structure/index.md
+++ b/src/content/vroong-tms-folder-structure/index.md
@@ -2,7 +2,7 @@
 layout: post
 title: "VROONG TMS 매니저웹 폴더 구조 변천사"
 date: "2017-07-07"
-tags: web, react
+tags: ["web", "react"]
 author: 최태건
 authorDesc: "플랫폼셀에서 웹 프론트엔드 개발을 담당하고 있습니다"
 titleImage: "./title.png"

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -10,10 +10,10 @@ import AuthorInfo, {
 import Icon from "../components/Icon";
 import { NavigationWrapper, NavigationLink } from "../components/Navigation";
 import Page from "../components/Page";
-import { TagList } from "../components/PostList";
+import { TagList as PostTagList } from "../components/PostList";
 import Container from "../components/Container";
 import IndexLayout from "../layouts";
-import { clearfix, getEmSize } from "../styles/mixins";
+import { getEmSize, resetUl } from "../styles/mixins";
 import { breakpoints, colors } from "../styles/variables";
 import { transformTags } from "../utils/tag";
 
@@ -25,7 +25,7 @@ interface IndexPageProps {
         description: string;
       };
     };
-    allMarkdownRemark: {
+    posts: {
       edges: Array<{
         node: {
           excerpt: string;
@@ -58,9 +58,15 @@ interface IndexPageProps {
                 };
               };
             };
-            tags?: string;
+            tags?: string[];
           };
         };
+      }>;
+    };
+    tagsGroup: {
+      tags: Array<{
+        tag: string;
+        count: number;
       }>;
     };
   };
@@ -145,7 +151,10 @@ const RecentExcerpt = styled.summary`
 `;
 
 const PostList = styled.ul`
-  ${clearfix} margin: 50px -10px 0;
+  display: flex;
+  flex-wrap: wrap;
+  flex: 2;
+  margin: 0;
   padding: 0;
   list-style: none;
   list-style-image: none;
@@ -156,7 +165,6 @@ const PostList = styled.ul`
 `;
 
 const ListItem = styled.li`
-  float: left;
   margin: 0 10px 40px;
   width: 300px;
   color: ${colors.gray80};
@@ -212,9 +220,85 @@ const ListItemImg = styled.div`
   }
 `;
 
+const GridWrapper = styled.div`
+  display: flex;
+  margin: 50px -10px 0;
+
+  @media (max-width: ${getEmSize(breakpoints.lg)}em) {
+    flex-wrap: wrap;
+    flex-direction: column;
+  }
+`;
+
+const TagListWrapper = styled.aside`
+  flex: 1;
+
+  @media (max-width: ${getEmSize(breakpoints.lg)}em) {
+    flex: 0;
+    width: 100%;
+    padding: 0;
+  }
+`;
+
+const TagListTitle = styled.h3`
+  margin: 0 0 0 40px;
+  font-size: 1em;
+  text-transform: uppercase;
+
+  @media (max-width: ${getEmSize(breakpoints.lg)}em) {
+    margin: 0 10px;
+    padding-top: 16px;
+    border-top: 1px solid ${colors.gray15};
+  }
+`;
+
+const TagList = styled.ul`
+  ${resetUl};
+  margin: 10px 0 0 40px;
+  padding: 0;
+
+  @media (max-width: ${getEmSize(breakpoints.lg)}em) {
+    margin: 10px 10px 0;
+  }
+`;
+
+const TagItem = styled.li`
+  margin: 0;
+  padding: 0;
+
+  &::before {
+    content: "-";
+    margin-right: 10px;
+    color: ${colors.gray60};
+  }
+
+  a {
+    color: ${colors.gray100};
+
+    i {
+      margin-left: 0.25em;
+      font-size: 0.875em;
+      font-style: normal;
+      color: ${colors.gray80};
+    }
+  }
+
+  a:hover {
+    color: ${colors.gray80};
+  }
+
+  @media (max-width: ${getEmSize(breakpoints.lg)}em) {
+    display: inline-block;
+
+    & + & {
+      margin-left: 20px;
+    }
+  }
+`;
+
 const IndexPage: React.SFC<IndexPageProps> = props => {
   const data = props.data;
-  if (!data.allMarkdownRemark || !data.allMarkdownRemark.edges.length) {
+  if (!data.posts || !data.posts.edges.length) {
     return (
       <IndexLayout>
         <Page>
@@ -223,11 +307,9 @@ const IndexPage: React.SFC<IndexPageProps> = props => {
       </IndexLayout>
     );
   }
-  const mostRecentPost = data.allMarkdownRemark.edges[0].node;
-  const posts = data.allMarkdownRemark.edges.filter(
-    (_, idx) => idx > 0 && idx < 10,
-  );
-  const isNextPageExist = data.allMarkdownRemark.edges.length > 10;
+  const mostRecentPost = data.posts.edges[0].node;
+  const posts = data.posts.edges.filter((_, idx) => idx > 0 && idx < 10);
+  const isNextPageExist = data.posts.edges.length > 10;
   return (
     <IndexLayout>
       <Page>
@@ -243,8 +325,7 @@ const IndexPage: React.SFC<IndexPageProps> = props => {
               <RecentBadge>
                 <strong>RECENT</strong>
                 &nbsp;&nbsp;|&nbsp;&nbsp;
-                {(mostRecentPost.frontmatter.tags || "")
-                  .split(",")
+                {(mostRecentPost.frontmatter.tags || [])
                   .map(x => `#${x.trim()}`)
                   .join(" ")}
               </RecentBadge>
@@ -257,41 +338,58 @@ const IndexPage: React.SFC<IndexPageProps> = props => {
           </RecentPageWrapper>
         </Link>
         <Container>
-          <PostList>
-            {posts.map(({ node }) => (
-              <ListItem key={node.fields.slug}>
-                <Link to={node.fields.slug}>
-                  <ListItemImgWrapper>
-                    <ListItemImg
-                      src={
-                        node.frontmatter.titleImage.childImageSharp.resize.src
-                      }
-                    />
-                  </ListItemImgWrapper>
-                  <ListItemTitle>{node.frontmatter.title}</ListItemTitle>
-                  <TagList>
-                    {transformTags(node.frontmatter.tags, true)}
-                  </TagList>
-                  <summary>{node.excerpt}</summary>
-                  <AuthorInfo>
-                    <AuthorAvatar
-                      src={node.frontmatter.author.avatar.children[0].fixed.src}
-                    />
-                    <AuthorName>{node.frontmatter.author.name}</AuthorName>
-                    <AuthorDesc>{node.frontmatter.date}</AuthorDesc>
-                  </AuthorInfo>
-                </Link>
-              </ListItem>
-            ))}
-          </PostList>
-          {isNextPageExist && (
-            <NavigationWrapper>
-              <NavigationLink prev to="/pages/2">
-                <Icon name="CARET_SMALL_LEFT" width={16} height={12} />
-                Older
-              </NavigationLink>
-            </NavigationWrapper>
-          )}
+          <GridWrapper>
+            <PostList>
+              {posts.map(({ node }) => (
+                <ListItem key={node.fields.slug}>
+                  <Link to={node.fields.slug}>
+                    <ListItemImgWrapper>
+                      <ListItemImg
+                        src={
+                          node.frontmatter.titleImage.childImageSharp.resize.src
+                        }
+                      />
+                    </ListItemImgWrapper>
+                    <ListItemTitle>{node.frontmatter.title}</ListItemTitle>
+                    <PostTagList>
+                      {transformTags(node.frontmatter.tags, true)}
+                    </PostTagList>
+                    <summary>{node.excerpt}</summary>
+                    <AuthorInfo>
+                      <AuthorAvatar
+                        src={
+                          node.frontmatter.author.avatar.children[0].fixed.src
+                        }
+                      />
+                      <AuthorName>{node.frontmatter.author.name}</AuthorName>
+                      <AuthorDesc>{node.frontmatter.date}</AuthorDesc>
+                    </AuthorInfo>
+                  </Link>
+                </ListItem>
+              ))}
+            </PostList>
+            {isNextPageExist && (
+              <NavigationWrapper>
+                <NavigationLink prev to="/pages/2">
+                  <Icon name="CARET_SMALL_LEFT" width={16} height={12} />
+                  Older
+                </NavigationLink>
+              </NavigationWrapper>
+            )}
+            <TagListWrapper>
+              <TagListTitle>Tags</TagListTitle>
+              <TagList>
+                {data.tagsGroup.tags.map(({ tag, count }) => (
+                  <TagItem key={tag}>
+                    <a href={`/tags/${tag}`}>
+                      {tag}
+                      <i>({count})</i>
+                    </a>
+                  </TagItem>
+                ))}
+              </TagList>
+            </TagListWrapper>
+          </GridWrapper>
         </Container>
       </Page>
     </IndexLayout>
@@ -306,7 +404,7 @@ export const pageQuery = graphql`
         description
       }
     }
-    allMarkdownRemark(
+    posts: allMarkdownRemark(
       sort: { fields: [frontmatter___date], order: DESC }
       limit: 11
     ) {
@@ -347,6 +445,12 @@ export const pageQuery = graphql`
             tags
           }
         }
+      }
+    }
+    tagsGroup: allMarkdownRemark {
+      tags: group(field: frontmatter___tags) {
+        tag: fieldValue
+        count: totalCount
       }
     }
   }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -137,7 +137,7 @@ const RecentTitle = styled.h2`
     top: -1.2rem;
   }
 
-  @media (max-width: ${getEmSize(breakpoints.lg)}em) {
+  @media (max-width: ${getEmSize(breakpoints.xl)}em) {
     font-size: 2rem;
 
     > sup {
@@ -159,7 +159,7 @@ const PostList = styled.ul`
   list-style: none;
   list-style-image: none;
 
-  @media (max-width: ${getEmSize(breakpoints.lg)}em) {
+  @media (max-width: ${getEmSize(breakpoints.xl)}em) {
     margin-top: 30px;
   }
 `;
@@ -173,7 +173,7 @@ const ListItem = styled.li`
     color: inherit;
   }
 
-  @media (max-width: ${getEmSize(breakpoints.lg)}em) {
+  @media (max-width: ${getEmSize(breakpoints.xl)}em) {
     margin-left: 0;
     margin-right: 0;
     width: 50%;
@@ -221,43 +221,48 @@ const ListItemImg = styled.div`
 `;
 
 const GridWrapper = styled.div`
+  position: relative;
   display: flex;
+  flex-direction: column;
   margin: 50px -10px 0;
 
-  @media (max-width: ${getEmSize(breakpoints.lg)}em) {
+  @media (max-width: ${getEmSize(breakpoints.xl)}em) {
     flex-wrap: wrap;
-    flex-direction: column;
   }
 `;
 
 const TagListWrapper = styled.aside`
-  flex: 1;
+  position: absolute;
+  right: 0;
+  width: 140px;
+  font-size: 0.875em;
 
-  @media (max-width: ${getEmSize(breakpoints.lg)}em) {
+  @media (max-width: ${getEmSize(breakpoints.xl)}em) {
+    position: static;
     flex: 0;
+    margin-top: 10px;
     width: 100%;
     padding: 0;
   }
 `;
 
 const TagListTitle = styled.h3`
-  margin: 0 0 0 40px;
+  margin: 0;
   font-size: 1em;
   text-transform: uppercase;
 
-  @media (max-width: ${getEmSize(breakpoints.lg)}em) {
+  @media (max-width: ${getEmSize(breakpoints.xl)}em) {
     margin: 0 10px;
     padding-top: 16px;
-    border-top: 1px solid ${colors.gray15};
   }
 `;
 
 const TagList = styled.ul`
   ${resetUl};
-  margin: 10px 0 0 40px;
+  margin: 10px 0 0 0;
   padding: 0;
 
-  @media (max-width: ${getEmSize(breakpoints.lg)}em) {
+  @media (max-width: ${getEmSize(breakpoints.xl)}em) {
     margin: 10px 10px 0;
   }
 `;
@@ -287,7 +292,7 @@ const TagItem = styled.li`
     color: ${colors.gray80};
   }
 
-  @media (max-width: ${getEmSize(breakpoints.lg)}em) {
+  @media (max-width: ${getEmSize(breakpoints.xl)}em) {
     display: inline-block;
 
     & + & {

--- a/src/styles/globalStyle.ts
+++ b/src/styles/globalStyle.ts
@@ -72,7 +72,7 @@ const globalStyle = css`
 
   tbody {
     tr {
-      &:nth-child(odd) {
+      &:nth-of-type(odd) {
         td {
           background-color: ${colors.ui.whisper};
         }

--- a/src/templates/post.tsx
+++ b/src/templates/post.tsx
@@ -46,15 +46,19 @@ interface ShareSheetProps {
   fixed: boolean;
 }
 
+const PostContainer = styled(Container)`
+  position: relative;
+`;
+
 const ShareSheet = styled.aside`
   position: ${(props: ShareSheetProps) => (props.fixed ? "fixed" : "absolute")};
-  top: ${(props: ShareSheetProps) => (props.fixed ? "131px" : "auto")};
+  top: ${(props: ShareSheetProps) => (props.fixed ? "131px" : "40px")};
   right: 50%;
   font-size: 0.75rem;
   font-weight: 500;
   text-align: right;
   color: ${colors.gray60};
-  transform: translateX(470px);
+  transform: translateX(550px);
 
   a,
   .SocialMediaShareButton {
@@ -105,7 +109,7 @@ const ShareSheet = styled.aside`
     }
   }
 
-  @media (max-width: ${getEmSize(breakpoints.lg)}em) {
+  @media (max-width: ${getEmSize(breakpoints.xl)}em) {
     display: none;
   }
 `;
@@ -362,7 +366,7 @@ class PageTemplate extends React.PureComponent<
             title={post.frontmatter.title}
             tags={post.frontmatter.tags}
           />
-          <Container>
+          <PostContainer>
             <Location>
               {({ location }) => (
                 <ShareSheet fixed={this.state.shareSheetFixed}>
@@ -407,7 +411,7 @@ class PageTemplate extends React.PureComponent<
               />
               <Article dangerouslySetInnerHTML={{ __html: post.html }} />
             </PostWrapper>
-          </Container>
+          </PostContainer>
         </Page>
       </IndexLayout>
     );

--- a/src/utils/tag.tsx
+++ b/src/utils/tag.tsx
@@ -1,8 +1,6 @@
 import * as React from "react";
 import { navigate } from "gatsby";
 
-type Tags = string | undefined;
-
 interface TagLinkProps {
   tagName: string;
 }
@@ -19,10 +17,7 @@ class TagLink extends React.PureComponent<TagLinkProps> {
   };
 }
 
-export const transformTags = (tags: Tags = "", withLink?: boolean) =>
-  withLink
-    ? tags.split(",").map(x => <TagLink key={x} tagName={x.trim()} />)
-    : tags
-        .split(",")
-        .map(x => `#${x.trim()}`)
-        .join(" ");
+export const transformTags = (tags: string[] | undefined, withLink?: boolean) =>
+  withLink && tags
+    ? tags.map(x => <TagLink key={x} tagName={x.trim()} />)
+    : tags.map(x => `#${x.trim()}`).join(" ");


### PR DESCRIPTION
![스크린샷 2020-12-09 오후 1 31 14](https://user-images.githubusercontent.com/1343747/101585757-c5b26000-3a23-11eb-8a6a-8729be488895.png)

![스크린샷 2020-12-08 오후 9 11 33](https://user-images.githubusercontent.com/1343747/101482572-40cf3400-399a-11eb-99a0-f4c77256fa7d.png)

블로그에 태그 목록을 표시하고, 태그 목록을 표출하는 로직을 graphql을 사용하도록 수정합니다.