### PR TITLE
[hotfix] 태그 리스트의 표출 방식 및 디스플레이 속성 조정

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -328,8 +328,6 @@ const IndexPage: React.SFC<IndexPageProps> = props => {
     predefinedCategories.includes(tag),
   );
 
-  console.log(mostRecentPost.frontmatter);
-
   return (
     <IndexLayout>
       <Page>

--- a/src/utils/tag.tsx
+++ b/src/utils/tag.tsx
@@ -1,23 +1,41 @@
 import * as React from "react";
-import { navigate } from "gatsby";
+import { Link } from "gatsby";
+import styled from "@emotion/styled";
 
 interface TagLinkProps {
   tagName: string;
 }
 
-class TagLink extends React.PureComponent<TagLinkProps> {
-  public render() {
-    return <span onClick={this.handleOnClick}>#{this.props.tagName}</span>;
-  }
+const TagLink: React.FC<TagLinkProps> = ({ tagName }) => {
+  const handleClick = React.useCallback(
+    (e: React.MouseEvent<HTMLSpanElement>) => {
+      e.stopPropagation();
+    },
+    [],
+  );
 
-  private handleOnClick = (e: React.MouseEvent<HTMLSpanElement>) => {
-    e.preventDefault();
-    e.stopPropagation();
-    navigate(`/tags/${this.props.tagName}`);
-  };
-}
+  return (
+    <StyledLink to={`/tags/${tagName}`} onClick={handleClick}>
+      #{tagName}
+    </StyledLink>
+  );
+};
 
-export const transformTags = (tags: string[] | undefined, withLink?: boolean) =>
+export const transformTags = (
+  tags: string[] | undefined = [],
+  withLink?: boolean,
+) =>
   withLink && tags
     ? tags.map(x => <TagLink key={x} tagName={x.trim()} />)
     : tags.map(x => `#${x.trim()}`).join(" ");
+
+const StyledLink = styled(Link)`
+  display: inline-block;
+  word-break: break-all;
+  color: inherit;
+  transition: text-shadow 0.3s;
+
+  &:not(:last-of-type) {
+    margin-right: 0.5em;
+  }
+`;


### PR DESCRIPTION
![스크린샷 2021-02-22 오후 7 27 21](https://user-images.githubusercontent.com/1343747/108696199-93a19c00-7544-11eb-8465-37794ed74797.png)

태그 리스트의 표출 방식 및 디스플레이 속성을 조정합니다.

* 접근성 향상을 위해 `a` 엘리먼트를 쓰도록 gatsby의 `Link` 컴포넌트를 사용합니다.
  * 클릭 핸들러는 단순하게 이벤트가 상위의 링크에 전파되는 것만 막도록 수정했습니다.
* `Link` 컴포넌트를 `inline-block`으로 표시하도록 하여, 태그 단위로 줄바꿈을 할 수 있도록 합니다.
* 태그 리스트 컴포넌트를 react hooks를 사용해 재작성합니다.
* `transformTags` 함수에서 `undefined`가 들어왔을 때 기본적으로 빈 배열을 사용하도록 수정해 상용 환경에서 깨지지 않게 합니다.

그 외에, 글이 정상적으로 렌더링되지 않는 문제를 해결하기 위해 임시로 넣었던 `console.log`를 제거했습니다.