### PR TITLE
[fix] Safari에서 정상적으로 word-break가 되지 않는 문제 긴급 수정

### DIFF
--- a/src/components/AWSBanner.tsx
+++ b/src/components/AWSBanner.tsx
@@ -46,7 +46,7 @@ const AWSBannerWrapper = styled.div`
   margin: 0;
   height: 300px;
   color: ${colors.white};
-  background: #010137 50% 0 url(${awsBg});
+  background: #010137 100% 0 url(${awsBg});
   background-size: cover;
 
   /* portrait phone */

--- a/src/components/AWSBanner.tsx
+++ b/src/components/AWSBanner.tsx
@@ -166,6 +166,7 @@ const AWSButton = styled(Link)`
 `;
 
 const NoBreakWrapper = styled.span`
+  display: inline-block;
   white-space: nowrap;
   margin-right: 0.2em;
 


### PR DESCRIPTION
<img width="426" alt="스크린샷 2021-05-11 오전 11 56 48" src="https://user-images.githubusercontent.com/1343747/117751383-f9521a00-b24f-11eb-9a55-f2cb173bceb0.png">

정상 작동 확인 후 긴급 머지합니다.