### PR TITLE
chore: 테마 컬러 및 open graph, 타이틀 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Mesh Korea Makers Blog
+# MESH KOREA | VROONG 테크 블로그
 
 메쉬코리아에서 기술, 유저 경험 및 공간 디자인, 서비스 기획 등 물류플랫폼을 만들기 위한 과정에 대한 고민과 그 해결을 담은 블로그입니다.
 
@@ -25,7 +25,7 @@
 
 #### 1. markdown 사용에 익숙하지 않으신가요?
 
-Makers Blog는 [Github Flavored Markdown](https://github.github.com/gfm/)을 사용합니다. 문법은 어렵지 않으니, 금방 배우실 수 있을 겁니다.
+테크 블로그는 [Github Flavored Markdown](https://github.github.com/gfm/)을 사용합니다. 문법은 어렵지 않으니, 금방 배우실 수 있을 겁니다.
 
 하지만 처음에는 어색하실 수 있죠. 그럴 때엔 [온라인 마크다운 에디터](https://stackedit.io/app)로 마크다운 문법을 자동으로 삽입해주는 버튼들과 함께 마크다운을 작성해보세요. macOS를 사용하신다면, Bear의 Markdown Compatibility 모드로 작성하셔도 좋습니다.
 

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -77,7 +77,7 @@ module.exports = {
     {
       resolve: `gatsby-plugin-manifest`,
       options: {
-        name: "Mesh Korea Makers Blog",
+        name: "MESH KOREA | VROONG 테크 블로그",
         icons: [
           {
             src: "/android-icon-192x192.png",
@@ -90,7 +90,7 @@ module.exports = {
             type: "image/png",
           },
         ],
-        theme_color: "#1b3993",
+        theme_color: "#EFF0F5",
         background_color: "#fff",
         display: "standalone",
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshkorea.github.io",
-  "description": "Mesh Korea Makers Blog",
+  "description": "MESH KOREA | VROONG 테크 블로그",
   "version": "1.1.0",
   "private": true,
   "author": "Mesh Korea Co., Ltd.",

--- a/src/layouts/index.tsx
+++ b/src/layouts/index.tsx
@@ -55,7 +55,10 @@ class IndexLayout extends React.Component {
               content="Mesh Korea, 메쉬코리아, 블로그, 기술 블로그, tech blog, makers blog, PO, Product Owner, 기획, 디자인, 개발, QA, 서버, 프론트엔드, 안드로이드, 웹, AWS, 머신러닝"
             />
             <meta property="og:url" content="https://meshkorea.github.io/" />
-            <meta property="og:title" content="Mesh Korea Makers Blog" />
+            <meta
+              property="og:title"
+              content="MESH KOREA | VROONG 테크 블로그"
+            />
             <meta
               property="og:description"
               content={data.site.siteMetadata.description}

--- a/src/templates/post.tsx
+++ b/src/templates/post.tsx
@@ -337,7 +337,7 @@ class PageTemplate extends React.PureComponent<
         <Helmet>
           <title>
             {post.frontmatter.title}
-            :: Mesh Korea Makers Blog
+            :: MESH KOREA | VROONG 테크 블로그
           </title>
           <meta name="description" content={post.excerpt} />
           <meta
@@ -353,7 +353,7 @@ class PageTemplate extends React.PureComponent<
           <meta
             property="og:title"
             content={`${post.frontmatter.title}
-            :: Mesh Korea Makers Blog`}
+            :: MESH KOREA | VROONG 테크 블로그`}
           />
           <meta property="og:description" content={post.excerpt} />
           <meta property="og:type" content="article" />

--- a/static/manifest.json
+++ b/static/manifest.json
@@ -1,5 +1,5 @@
 {
-  "name": "Mesh Korea Makers Blog",
+  "name": "MESH KOREA | VROONG 테크 블로그",
   "icons": [
       {
           "src": "src/components/assets/android-icon-192x192.png",
@@ -12,7 +12,7 @@
           "type": "image/png"
       }
   ],
-  "theme_color": "#1b3993",
+  "theme_color": "#EFF0F5",
   "background_color": "#fff",
   "display": "standalone"
 }


### PR DESCRIPTION
BEFORE
<img width="1708" alt="스크린샷 2021-06-22 오후 9 46 58" src="https://user-images.githubusercontent.com/1343747/122927407-cc8f3780-d3a3-11eb-934a-ec49b176e424.png">

AFTER
<img width="1708" alt="스크린샷 2021-06-22 오후 9 46 57" src="https://user-images.githubusercontent.com/1343747/122927396-ca2cdd80-d3a3-11eb-9e74-b8e8800c30df.png">

* 테크 블로그의 테마 컬러를 사파리 및 크롬 모바일, 삼성 인터넷에서 seamless하게 보일 수 있도록 수정합니다.
    * macOS 12부터 적용되며, 다크 모드에서는 브라우저 헤더가 밝은색으로 나오지 않습니다... (다크 모드 컬러 재구성 필요)
* "Makers Blog"의 흔적을 제거합니다.